### PR TITLE
Update install_packages.r

### DIFF
--- a/src/run_app_locally/install_packages.r
+++ b/src/run_app_locally/install_packages.r
@@ -16,22 +16,21 @@
 # packages required to run the app locally
 list_of_packages <- c(
   "bcmaps",
-  "data.table", #to do: consider using readr:read_csv instead of data.table::fread (see load_metadata.r)
+  "fs",
+  "here",
   "htmlwidgets",
   "knitr",
   "leaflet",
   "leaflet.esri",
-  "lubridate",
   "mapview",
+  "sf",
   "shiny",
   "shinydashboard",
   "shinyjs",
-  "sf",
-  "tidyverse",
+  "tidyverse", # mostly using dplyr, tidyr, readr, lubridate
   "quarto",
   "webshot",
-  "mapshot",
-  "fs"
+  "zip"
 )
 
 # identify which packages are not yet installed on user computer


### PR DESCRIPTION
Added: `here`, `zip`

Removed: `lubridate` (now in core tidyverse), `mapshot` (not a package, this is a function in `mapview`) and data.table (no longer in use as per note, had previously replaced `data.table::fread` with base R `read.csv`)

Also: Put package list back into alphabetical order