### PR TITLE
Fix contacts rnd2

### DIFF
--- a/module_issue_wildfire_smoke.r
+++ b/module_issue_wildfire_smoke.r
@@ -430,8 +430,11 @@ issueWildfireSmoke <- function(input, output, session){
       showNotification("No author selected; please select an author.", type = "error")
     } else if (length(selRegions$ids) == 0) {
       showNotification("No region selected; please select a region.", type = "error")
+    } else if (input$location == "") {
+        showNotification("No location description provided; please select or type a location description.", type = "error")
     } else {
 
+      
       ncomplete <- length(completeNotificationIDs)
       if (ncomplete > 0) {
         # remove the notification for completed steps if the genWarning
@@ -443,7 +446,8 @@ issueWildfireSmoke <- function(input, output, session){
         completeNotificationIDs <<- completeNotificationIDs[-c(seq(ncomplete))]
       }
       
-      showNotification("Rendering map...")
+      showNotification("Preparing files. Please wait for completion notification.",
+                       duration = 17)
       
       issueBasename <- "wildfire_smoke_issue"
       cliprect <- c(140, 147, 610, 480)  # top, left, width, height
@@ -504,21 +508,21 @@ issueWildfireSmoke <- function(input, output, session){
       
       writeLines(alttext, sprintf(here::here("outputs", "rnw", "%s_%s_map_alttext.txt"), currentDate, issueBasename))
       
-      id2 <- showNotification("Writing text files complete!", duration = NULL)
-      completeNotificationIDs <<- c(completeNotificationIDs, c(id, id2))
+      #id2 <- showNotification("Writing text files complete!", duration = NULL)
+      #completeNotificationIDs <<- c(completeNotificationIDs, c(id, id2))
 
       output$alttext <- renderText(alttext)
       
       
       # PDF
-      showNotification("Generating PDF...")
+     # showNotification("Generating PDF...")
       knitr::knit2pdf(sprintf(here::here("src", "rnw", "%s.rnw"), issueBasename), clean = TRUE,
                       output = sprintf(here::here("outputs", "rnw", "%s_%s.tex"), currentDate, issueBasename))
 
-      id <- showNotification("PDF generation complete!", duration = NULL)
+     # id <- showNotification("PDF generation complete!", duration = NULL)
       
       # Quarto
-      showNotification("Generating Markdown...")
+    #  showNotification("Generating Markdown...")
       
       quarto::quarto_render(input = sprintf(here::here("%s.qmd"), issueBasename),
                             output_format = "markdown",
@@ -532,7 +536,7 @@ issueWildfireSmoke <- function(input, output, session){
                                                   location = input$location),
                             debug = FALSE)
       
-      id <- showNotification("Markdown generation complete!", duration = NULL)
+     # id <- showNotification("Markdown generation complete!", duration = NULL)
       
       markdown_output_file <- list.files(pattern = sprintf("%s_%s.md", currentDate, issueBasename), full.names = TRUE)
       fs::file_move(path = paste0(markdown_output_file), new_path = here::here("outputs", "qmd"))
@@ -540,7 +544,10 @@ issueWildfireSmoke <- function(input, output, session){
       map_output_file <- list.files(pattern = sprintf("%s_%s_map.html", currentDate, issueBasename), full.names = TRUE)
       fs::file_move(path = paste0(map_output_file), new_path = here::here("outputs", "qmd"))
       
-      id <- showNotification("Markdown file moved to outputs/qmd directory.")
+      id <- showNotification("Processing complete. Files are ready for downloading.", 
+                       duration = NULL)
+      
+      completeNotificationIDs <<- c(completeNotificationIDs, c(id))
 
     } #end else
   }) #end observeEvent for generating report
@@ -564,5 +571,4 @@ issueWildfireSmoke <- function(input, output, session){
     },
     contentType = "application/zip"
   )
-  
 }

--- a/wildfire_smoke_end.qmd
+++ b/wildfire_smoke_end.qmd
@@ -46,7 +46,7 @@ source(here::here("load_metadata.r"))
 #AQ met information
 
 ENVcontact <- aq_mets |>
-  filter(nickname == params$sel_aqMet) |>
+  filter(fullname == params$sel_aqMet) |>
   mutate(contact = paste(fullname_typeset, title, ministry, phone, sep = "<br />")) |> 
   pull(contact)
 

--- a/wildfire_smoke_end.qmd
+++ b/wildfire_smoke_end.qmd
@@ -2,7 +2,6 @@
 title: "Air Quality Warning - Wildfire Smoke" 
 type: "wildfire_smoke" 
 date: "`r Sys.Date()`" 
-toc: true
 params: 
   sel_aqMet: "Sakshi Jain" 
   lastWarning: "2025-02-10" 

--- a/wildfire_smoke_end.qmd
+++ b/wildfire_smoke_end.qmd
@@ -127,6 +127,6 @@ Real-time air quality information is available on the [BC Air Quality website](h
 
 {{< card_start width="wide" >}}
 
-`r paste(HAcontact$html_string, collapse = "<br />")`
+`r paste(HAcontact$html_string, collapse = "\n")`
 
 {{< card_end >}}

--- a/wildfire_smoke_end.qmd
+++ b/wildfire_smoke_end.qmd
@@ -127,6 +127,6 @@ Real-time air quality information is available on the [BC Air Quality website](h
 
 {{< card_start width="wide" >}}
 
-`r paste(HAcontact$html_string)`
+`r paste(HAcontact$html_string, collapse = "<br />")`
 
 {{< card_end >}}

--- a/wildfire_smoke_end.qmd
+++ b/wildfire_smoke_end.qmd
@@ -127,6 +127,6 @@ Real-time air quality information is available on the [BC Air Quality website](h
 
 {{< card_start width="wide" >}}
 
-`r paste(HAcontact$html_string, collapse = "\n")`
+`r paste(HAcontact$html_string, collapse = "\n\n")`
 
 {{< card_end >}}

--- a/wildfire_smoke_end.qmd
+++ b/wildfire_smoke_end.qmd
@@ -51,7 +51,8 @@ ENVcontact <- aq_mets |>
 
 HAcontact <- health_contact |>
   filter(authority %in% params$sel_healthAuth) |>
-  mutate(authority = factor(authority))|> select(authority, contact) |>
+  mutate(authority = factor(authority))|> 
+  select(authority, contact) |>
   group_by(authority) |> 
   summarise(html_string = paste(contact, collapse="<br />" ))
 ```
@@ -126,7 +127,6 @@ Real-time air quality information is available on the [BC Air Quality website](h
 
 {{< card_start width="wide" >}}
 
-<!-- `r paste(HAcontact$contact, collapse = "<br />")` -->
 `r paste(HAcontact$html_string)`
 
 {{< card_end >}}

--- a/wildfire_smoke_end.qmd
+++ b/wildfire_smoke_end.qmd
@@ -49,9 +49,11 @@ ENVcontact <- aq_mets |>
   mutate(contact = paste(fullname_typeset, title, ministry, phone, sep = "<br />")) |> 
   pull(contact)
 
-HAcontact <- health_contact |> 
-   filter(authority %in% params$sel_healthAuth) |> 
-   mutate(authority = factor(authority))
+HAcontact <- health_contact |>
+  filter(authority %in% params$sel_healthAuth) |>
+  mutate(authority = factor(authority))|> select(authority, contact) |>
+  group_by(authority) |> 
+  summarise(html_string = paste(contact, collapse="<br />" ))
 ```
 
 ```{r}
@@ -124,6 +126,7 @@ Real-time air quality information is available on the [BC Air Quality website](h
 
 {{< card_start width="wide" >}}
 
-`r paste(HAcontact$contact, collapse = "<br />")`
+<!-- `r paste(HAcontact$contact, collapse = "<br />")` -->
+`r paste(HAcontact$html_string)`
 
 {{< card_end >}}

--- a/wildfire_smoke_issue.qmd
+++ b/wildfire_smoke_issue.qmd
@@ -75,7 +75,7 @@ HAcontact <- health_contact |>
   mutate(authority = factor(authority))|> 
   select(authority, contact) |>
   group_by(authority) |> 
-  summarise(html_string = paste(contact, collapse="<br />" ))
+  summarise(html_string = paste(contact, collapse="\n" ))
 
 # retrieve descriptions (utility_files/eccc_descriptions.csv) for each affected region
 # descriptions included at end of bulletin
@@ -306,7 +306,7 @@ People more likely to be negatively impacted by outdoor air pollution should red
 **Media questions regarding health implications of wildfires:**
 
 {{< card_start  width="wide" >}}
-`r paste(HAcontact$html_string, collapse = "<br />")`
+`r paste(HAcontact$html_string, collapse = "\n")`
 {{< card_end >}}
 
 ## Regions included under this Air Quality Warning

--- a/wildfire_smoke_issue.qmd
+++ b/wildfire_smoke_issue.qmd
@@ -71,8 +71,11 @@ unique_HA <- unique_HA [! unique_HA %in% ""]
 
 # filter health authorities, always include FNHA
 HAcontact <- health_contact |> 
-   filter(authority %in% c("First Nations Health Authority", unique_HA)) |> 
-   mutate(authority = factor(authority))
+  filter(authority %in% c("First Nations Health Authority", unique_HA)) |> 
+  mutate(authority = factor(authority))|> 
+  select(authority, contact) |>
+  group_by(authority) |> 
+  summarise(html_string = paste(contact, collapse="<br />" ))
 
 # retrieve descriptions (utility_files/eccc_descriptions.csv) for each affected region
 # descriptions included at end of bulletin
@@ -303,7 +306,7 @@ People more likely to be negatively impacted by outdoor air pollution should red
 **Media questions regarding health implications of wildfires:**
 
 {{< card_start  width="wide" >}}
-`r paste(HAcontact$contact, collapse = "<br />")`
+`r paste(HAcontact$html_string)`
 {{< card_end >}}
 
 ## Regions included under this Air Quality Warning

--- a/wildfire_smoke_issue.qmd
+++ b/wildfire_smoke_issue.qmd
@@ -306,7 +306,7 @@ People more likely to be negatively impacted by outdoor air pollution should red
 **Media questions regarding health implications of wildfires:**
 
 {{< card_start  width="wide" >}}
-`r paste(HAcontact$html_string, collapse = "\n")`
+`r paste(HAcontact$html_string, collapse = "\n\n")`
 {{< card_end >}}
 
 ## Regions included under this Air Quality Warning

--- a/wildfire_smoke_issue.qmd
+++ b/wildfire_smoke_issue.qmd
@@ -75,7 +75,7 @@ HAcontact <- health_contact |>
   mutate(authority = factor(authority))|> 
   select(authority, contact) |>
   group_by(authority) |> 
-  summarise(html_string = paste(contact, collapse="\n" ))
+  summarise(html_string = paste(contact, collapse="<br />" ))
 
 # retrieve descriptions (utility_files/eccc_descriptions.csv) for each affected region
 # descriptions included at end of bulletin

--- a/wildfire_smoke_issue.qmd
+++ b/wildfire_smoke_issue.qmd
@@ -235,7 +235,7 @@ People more likely to be negatively impacted by outdoor air pollution should red
 
 -   Mild irritation and discomfort such as eye, nose and throat irritation, headaches or a mild cough are common, and usually disappear when the smoke clears.
 
--   More serious but less commmon symptoms include wheezing, chest pains or severe cough.
+-   More serious but less common symptoms include wheezing, chest pains or severe cough.
 
 -   People with asthma or other chronic illness should follow any personal care plans designed with their family physicians.
 
@@ -257,7 +257,7 @@ People more likely to be negatively impacted by outdoor air pollution should red
 
 -   If you must spend time outdoors, a well-constructed, well-fitting and properly worn respirator type mask (such as a NIOSH-certified N95 or equivalent respirator) can reduce your exposure to the fine particles in the smoke. Even though exposure may be reduced, there can still be risks to health.
 
--   Check on others who are in your care or live nearby who may be more likley to be impacted by wildfire smoke.
+-   Check on others who are in your care or live nearby who may be more likely to be impacted by wildfire smoke.
 
 -   Always follow guidance from local authorities. 
 
@@ -306,7 +306,7 @@ People more likely to be negatively impacted by outdoor air pollution should red
 **Media questions regarding health implications of wildfires:**
 
 {{< card_start  width="wide" >}}
-`r paste(HAcontact$html_string)`
+`r paste(HAcontact$html_string, collapse = "<br />")`
 {{< card_end >}}
 
 ## Regions included under this Air Quality Warning


### PR DESCRIPTION
- simplified progress messaging in app (files processing; ready for downloading)
- added error message if location field is left empty
- wildfire end.qmd`: removed toc;  select `fullname` instead of `nickname` for meteorologist
- fixes spacing between health authority contacts 
- fixed a couple of typos in `wildfire_issue.qmd`

note: On my local machine, the `.md` file produced seems to be dropping the equal sign in within `card_start`.  For example,

`wildfire_smoke_issue.qmd`  `{{<card_start width = "wide" >}}`
![image](https://github.com/user-attachments/assets/450c103d-7a9e-4e21-ae70-6c734e2e0e9c)

renders `wildfire_smoke_issue.md`  `{{<card_start width  "wide" >}}`
![image](https://github.com/user-attachments/assets/8edef3f4-67b6-4bc8-b36e-066c2ce6fc13)

This has implications for how the information presents on the GitHib pages. I am suspicious it may be related to recent package updates I completed.  Hopefully the `.md` files renders correctly for others.

