### PR TITLE
colour ECCC regions grey

### DIFF
--- a/module_issue_wildfire_smoke.r
+++ b/module_issue_wildfire_smoke.r
@@ -208,7 +208,7 @@ issueWildfireSmoke <- function(input, output, session){
         opacity = 0.75,
         color = "black",
         weight = 2.5,
-        fillColor = "#FFF716",
+        fillColor = "grey",
         options = pathOptions(pane = "ames_polygons"),
         label = ~NAME,
         labelOptions = labelOptions(textsize = "15px"),
@@ -372,7 +372,7 @@ issueWildfireSmoke <- function(input, output, session){
                   opacity = 1,
                   color = "black",
                   weight = 1.75,
-                  fillColor = "#FFF716",
+                  fillColor = "grey",
                   options = pathOptions(pane = "ames_polygons"),
                   highlightOptions = highlightOptions(sendToBack = TRUE)) |> 
       addCircleMarkers(data = cities,

--- a/wildfire_smoke_issue.qmd
+++ b/wildfire_smoke_issue.qmd
@@ -113,7 +113,7 @@ m <- leaflet() |>
         fillOpacity = 0.025,
         opacity = 0.75,
         color = "black",
-        fillColor = "#FFF716",
+        fillColor = "grey",
         stroke = TRUE,
         weight = 1,
         smoothFactor = 0.2,
@@ -127,7 +127,7 @@ m <- leaflet() |>
                   opacity = 0.65,
                   color = "black",
                   weight = 1.75,
-                  fillColor = "#FFF716",
+                  fillColor = "grey",
                   label = ~NAME,
                   labelOptions = labelOptions(textsize = "15px"))
 


### PR DESCRIPTION
Colouring the regions grey for this fire season to coincide with ECCCs air quality statements. The colours will be changed back to yellow once ECCC rolls out their their new system in the coming months.

fixes #31 