### PR TITLE
add cards for contacts and update logos to align with wildfire warnings

### DIFF
--- a/community_smoke_end.qmd
+++ b/community_smoke_end.qmd
@@ -98,13 +98,24 @@ if (params$pollutant == "PM25") {
 ```
 
 ```{r ENVcontact, include=FALSE}
+#| label: ENVcontact
+#| results: asis
+#| strip.white: false
+
+if (params$outputFormat == "markdown") sep_type <- "<br />" else sep_type <- "  \n"
+
+# AQ met information
 ENVcontact <- aq_mets |>
   filter(nickname == params$sel_aqMet) |>
-  mutate(contact = paste(fullname_typeset, title, ministry, phone, sep = "<br />")) |> 
-  pull(contact)
+  mutate(contact = paste(fullname_typeset, title, ministry, phone, sep = sep_type)) |> 
+  pull(contact) 
 ```
 
 ```{r HAcontact, include=FALSE}
+#| label: HAcontact
+#| results: asis
+
+if (params$outputFormat == "markdown") sep_type <- "<br />" else sep_type <- "  \n"
 
 HAauth <- Health_Authority %>%
   filter(Station == params$station) %>%
@@ -114,9 +125,9 @@ HAcontact <- health_contact |>
     filter(authority == HAauth) |>
     select(authority, contact) |>
     group_by(authority) |>
-    summarise(html_string = paste(contact, collapse = "<br />"))
-
+    summarise(html_string = paste(contact, collapse = sep_type))
 ```
+
 
 ```{r table-setup, include=FALSE}
 

--- a/community_smoke_issue.qmd
+++ b/community_smoke_issue.qmd
@@ -166,6 +166,10 @@ voluntary_reduction_O3 <- paste0(
 ```
 
 ```{r HAcontact, include=FALSE}
+#| label: HAcontact
+#| results: asis
+
+if (params$outputFormat == "markdown") sep_type <- "<br />" else sep_type <- "  \n"
 
 HAauth <- Health_Authority %>%
   filter(Station == params$station) %>%
@@ -175,8 +179,7 @@ HAcontact <- health_contact |>
     filter(authority == HAauth) |>
     select(authority, contact) |>
     group_by(authority) |>
-    summarise(html_string = paste(contact, collapse = "<br />"))
-
+    summarise(html_string = paste(contact, collapse = sep_type))
 ```
 
 ```{r pollutant_specific_clauses, include=FALSE}
@@ -519,11 +522,17 @@ final_table <- pt4 %>%
 ```
 
 ```{r ENVcontact, include=FALSE}
+#| label: ENVcontact
+#| results: asis
+#| strip.white: false
 
+if (params$outputFormat == "markdown") sep_type <- "<br />" else sep_type <- "  \n"
+
+# AQ met information
 ENVcontact <- aq_mets |>
   filter(nickname == params$sel_aqMet) |>
-  mutate(contact = paste(fullname_typeset, title, ministry, phone, sep = "<br />")) |> 
-  pull(contact)
+  mutate(contact = paste(fullname_typeset, title, ministry, phone, sep = sep_type)) |> 
+  pull(contact) 
 ```
 
 ```{r}
@@ -611,6 +620,7 @@ if (params$outputFormat == "markdown") cat(logo_image_line, sep="\n\n")
 ```
 
 [`r paste(":::")`]{.content-visible when-format="markdown"}
+
 # Air quality warning `r title_burn_advisory` `r title_ICE` for `r params$station` - `r format(Sys.Date(), "%B %d, %Y")`
 
 `r first_paragraph`


### PR DESCRIPTION

- addressed #62 shortcodes for: contacts as well as the code to switch separators for PDF vs MD
- addressed #66 logo generation now matches the wildfire smoke templates (and includes FNHA).

Questions that came up, though I think we can ticket out and handle these separately:

- On the mockups we had planned to use accordions for the health tips, however we would need to refactor how health tips are generated (in general I think we don't need to paste the whole section and can only paste in the parts that are unique to pollutants or time of year)
- We also planned to use info boxes for some pollutant specific info, do we still want to? (that might cause us to refactor some bits)
- I'm also unclear about how close we want to mirror the text for more info from the wildfire smoke (that would move away from a bulleted list to cards



<img width="469" height="433" alt="image" src="https://github.com/user-attachments/assets/5d6be762-1d64-4aa6-9679-0316b641aabb" />
