### PR TITLE
add boolean YAML parameter "bylaw" and clean up other YAML parameters

### DIFF
--- a/local_emissions_end.qmd
+++ b/local_emissions_end.qmd
@@ -1,12 +1,4 @@
 ---
-title: "`r if (params$burnRestrictionStatus == 0) { 
-            paste('Air quality warning ended for', params$location)
-                } else if (params$burnRestrictionStatus == 1) {
-        paste('Air quality warning and open burning restrictions ended for', params$location)
-        } else {
-        paste('Air quality warning ended for', params$location, '- open burning restrictions remain in effect')
-        }`"
-type: "local_emissions"
 date: "`r Sys.Date()`"
 params: 
   pollutant: "PM25 & PM10"
@@ -20,13 +12,6 @@ params:
   burnRestrictionArea: ""
   burnRestrictionEndDate: "2025-09-28"
   burnRestrictionEndTime: "12:00 PM"
-ice: "End"
-pollutant: "`r params$pollutant`"
-author: "`r params$aqMet`"
-customMessage: "`r params$customMessage`"
-location: "`r params$location`"
-outputFormat: "`r params$outputFormat`" 
-burnRestrictions: "`r ifelse(params$burnRestrictionStatus < 2, 0, params$burnRestrictionStatus)`"
 format:
   markdown: default
   pdf:

--- a/local_emissions_issue.qmd
+++ b/local_emissions_issue.qmd
@@ -1,10 +1,4 @@
 ---
-title: "`r paste0(
-  'Air quality warning ', 
-  ifelse(params$burnRestrictions > 0, 'and open burning restrictions ', ''),
-  'in effect for ',
-  params$location)`"
-type: "local_emissions"
 date: "`r Sys.Date()`"
 params: 
   ice: "Issue" # Issue; Continue
@@ -19,13 +13,6 @@ params:
   burnRestrictionArea: ""
   burnRestrictionEndDate: "2025-09-28"
   burnRestrictionEndTime: "12:00 PM"
-ice: "`r params$ice`"
-pollutant: "`r params$pollutant`"
-author: "`r params$aqMet`"
-customMessage: "`r params$customMessage`"
-location: "`r params$location`"
-outputFormat: "`r params$outputFormat`"
-burnRestrictions: "`r params$burnRestrictions`"
 format:
   markdown: default
   pdf:

--- a/module_end_local_emissions.r
+++ b/module_end_local_emissions.r
@@ -294,6 +294,16 @@ endLocalEmissions <- function(input, output, session){
       on.exit(progress$close())
       progress$set(message = "Preparing files...", value = 0)
       
+      # Create YAML parameters for rendering via quarto_render()
+      burnRestrictions <- ifelse(input$burnRestrictionStatus < 2, 0, input$burnRestrictionStatus)
+      warningTitle <-if (input$burnRestrictionStatus == 0) { 
+            paste('Air quality warning ended for', input$location)
+                } else if (input$burnRestrictionStatus == 1) {
+                  paste('Air quality warning and open burning restrictions ended for', input$location)
+                  } else {
+                    paste('Air quality warning ended for', input$location, '- open burning restrictions remain in effect')
+                  }
+      
       # Clean strings for safe filenames
       location_clean <- gsub("\\s+", "_", input$location)
       pollutant_clean <- tolower(gsub(" ", "", gsub("&", "_", input$pollutant)))
@@ -325,7 +335,19 @@ endLocalEmissions <- function(input, output, session){
                               burnRestrictionEndTime = input$burnRestrictionEndTime,
                               issuedate = input$issuedate,
                               customMessage = input$customMessage,
-                              outputFormat = "markdown"),
+                              outputFormat = "markdown"
+                              ),
+                            # YAML parameters to add to .md header
+                            metadata = list(
+                              author = input$aqMet,
+                              burnRestrictions = burnRestrictions,
+                              customMessage = input$customMessage,
+                              ice = "End",
+                              location = input$location,
+                              pollutant = input$pollutant,
+                              title = warningTitle,
+                              type = "local_emissions"
+                              ),
                             debug = FALSE)
       
       # Relocate the .md file to outputs/ directory
@@ -352,6 +374,10 @@ endLocalEmissions <- function(input, output, session){
                               issuedate = input$issuedate,
                               customMessage = input$customMessage,
                               outputFormat = "pdf"),
+                            # YAML parameters for .pdf generation
+                            metadata = list(
+                              title = warningTitle
+                            ),
                             debug = FALSE)
     
     # Relocate the .pdf to outputs/ directory

--- a/module_end_pollution_prevention.r
+++ b/module_end_pollution_prevention.r
@@ -155,6 +155,13 @@ endPollutionPrevention <- function(input, output, session){
       on.exit(progress$close())
       progress$set(message = "Preparing files...", value = 0)
       
+      # Create YAML parameters for .qmd
+      warningTitle <- paste(
+        "Pollution Prevention Notice and open burning restrictions ended within", 
+        input$burnRestrictionArea
+        )
+
+      
       # Set output file name
       output_file_name <- sprintf("%s_%s", input$nearestMonitor, "end_pollution_prevention") 
 
@@ -172,6 +179,14 @@ endPollutionPrevention <- function(input, output, session){
                               issuedate = input$issuedate,
                               customMessage = input$customMessage,
                               outputFormat = "markdown"),
+                            metadata = list(
+                              author = input$aqMet,
+                              burnRestrictions = 0,
+                              ice = "End",
+                              location = input$nearestMonitor,
+                              title = warningTitle,
+                              type = "pollution_prevention"
+                              ),
                             debug = FALSE)
       
       # Relocate the .md file to outputs/ directory
@@ -193,6 +208,9 @@ endPollutionPrevention <- function(input, output, session){
                               issuedate = input$issuedate,
                               customMessage = input$customMessage,
                               outputFormat = "pdf"),
+                            metadata = list(
+                              title = warningTitle
+                            ),
                             debug = FALSE)
     
     # Relocate the .pdf to outputs/ directory

--- a/module_end_wildfire_smoke.r
+++ b/module_end_wildfire_smoke.r
@@ -157,6 +157,13 @@ endWildfireSmoke <- function(input, output, session){
                                                   healthAuth = input$healthAuth,
                                                   location = input$location,
                                                   outputFormat = "markdown"),
+                            metadata = list(
+                              author = input$aqMet, 
+                              ice = "End",
+                              location = input$location,
+                              title = "Air quality warning for wildfire smoke ended",
+                              type = "wildfire_smoke"
+                            ),
                             debug = FALSE)
       
       # Relocate the .md file to outputs/ directory
@@ -177,6 +184,9 @@ endWildfireSmoke <- function(input, output, session){
                                                   healthAuth = input$healthAuth,
                                                   location = input$location,
                                                   outputFormat = "pdf"),
+                            metadata = list(
+                              title = "Air quality warning for wildfire smoke ended"
+                            ),
                             debug = FALSE)
   
       

--- a/module_issue_local_emissions.r
+++ b/module_issue_local_emissions.r
@@ -297,6 +297,13 @@ issueLocalEmissions <- function(input, output, session){
       on.exit(progress$close())
       progress$set(message = "Preparing files...", value = 0)
       
+      # Create YAML parameters for .qmd
+      bylawBoolean <- isTRUE(any(c("Burns Lake", "Duncan", "Houston", "Prince George", "Smithers", "Valemount") == input$location, na.rm = TRUE))
+      warningTitle <- paste0("Air quality warning ", 
+                             ifelse(input$burnRestrictions > 0, "and open burning restrictions ", " "), 
+                             "in effect for ",
+                             input$location)
+      
       # Clean strings for safe filenames
       location_clean <- gsub("\\s+", "_", input$location)
       pollutant_clean <- tolower(gsub(" ", "", gsub("&", "_", input$pollutant)))
@@ -321,17 +328,28 @@ issueLocalEmissions <- function(input, output, session){
                             output_format = "markdown",
                             execute_params = list(
                               aqMet = input$aqMet,
-                              pollutant = input$pollutant,
-                              ice = input$ice,
-                              location = input$location,
+                              customMessage = input$customMessage,
                               burnRestrictions = input$burnRestrictions,
                               burnRestrictionArea = input$burnRestrictionArea,
                               burnRestrictionEndDate = input$burnRestrictionEndDate,
                               burnRestrictionEndTime = input$burnRestrictionEndTime,
+                              ice = input$ice,
                               issuedate = input$issuedate,
+                              location = input$location,
                               nextUpdate = input$nextUpdate,
-                              customMessage = input$customMessage,
-                              outputFormat = "markdown"),
+                              outputFormat = "markdown",
+                              pollutant = input$pollutant
+                              ),
+                            metadata = list(
+                              author = input$aqMet,
+                              burnRestrictions = input$burnRestrictions,
+                              bylaw = bylawBoolean,
+                              ice = input$ice,
+                              location = input$location,
+                              pollutant = input$pollutant,
+                              title = warningTitle,
+                              type = "local_emissions"
+                              ),
                             debug = FALSE)
       
       # Relocate the .md file to outputs/ directory
@@ -359,6 +377,9 @@ issueLocalEmissions <- function(input, output, session){
                               nextUpdate = input$nextUpdate,
                               customMessage = input$customMessage,
                               outputFormat = "pdf"),
+                            metadata = list(
+                              title = warningTitle
+                              ),
                             debug = FALSE)
       
       # Relocate the .pdf to outputs/ directory

--- a/module_issue_pollution_prevention.r
+++ b/module_issue_pollution_prevention.r
@@ -229,6 +229,12 @@ issuePollutionPrevention <- function(input, output, session){
       on.exit(progress$close())
       progress$set(message = "Preparing files...", value = 0)
       
+      # Create YAML parameters for .qmd
+      warningTitle <- paste(
+        "Pollution Prevention Notice and open burning restrictions are in effect within", 
+        input$burnRestrictionArea
+        )
+      
       # Set output file name
       output_file_name <- sprintf("%s_%s_%s", input$nearestMonitor, tolower(input$ice), "pollution_prevention") 
 
@@ -251,6 +257,14 @@ issuePollutionPrevention <- function(input, output, session){
                               nextUpdate = input$nextUpdate,
                               customMessage = input$customMessage,
                               outputFormat = "markdown"),
+                            metadata = list(
+                              author = input$aqMet,
+                              ice = input$ice,
+                              location = input$nearestMonitor,
+                              title = warningTitle,
+                              type = "pollution_prevention",
+                              burnRestrictions = input$burnRestrictions
+                              ),
                             debug = FALSE)
       
       # Relocate the .md file to outputs/ directory
@@ -277,6 +291,9 @@ issuePollutionPrevention <- function(input, output, session){
                               nextUpdate = input$nextUpdate,
                               customMessage = input$customMessage,
                               outputFormat = "pdf"),
+                            metadata = list(
+                              title = warningTitle
+                            ),
                             debug = FALSE)
       
       # Relocate the .pdf to outputs/ directory

--- a/module_issue_wildfire_smoke.r
+++ b/module_issue_wildfire_smoke.r
@@ -520,9 +520,15 @@ issueWildfireSmoke <- function(input, output, session){
                                                   smokeDuration = input$smokeDuration,
                                                   selRegionsIDs = selRegions$ids,
                                                   customMessage = input$smokeMessage,
-                                                  ice = "Issue",
                                                   location = input$location,
                                                   outputFormat = "markdown"),
+                            metadata = list(
+                              author = input$aqMet,
+                              ice = "Issue",
+                              location = input$location,
+                              title = "Air quality warning in effect for wildfire smoke",
+                              type = "wildfire_smoke" 
+                            ),
                             debug = FALSE)
       
       # Relocate the .md file to outputs/ directory
@@ -545,9 +551,11 @@ issueWildfireSmoke <- function(input, output, session){
                                                   smokeDuration = input$smokeDuration,
                                                   selRegionsIDs = selRegions$ids,
                                                   customMessage = input$smokeMessage,
-                                                  ice = "Issue",
                                                   location = input$location,
                                                   outputFormat = "pdf"),
+                            metadata = list(
+                              title = "Air quality warning in effect for wildfire smoke"
+                            ),
                             debug = FALSE)
      
      # Relocate the .pdf to outputs/ directory

--- a/pollution_prevention_end.qmd
+++ b/pollution_prevention_end.qmd
@@ -1,6 +1,4 @@
 ---
-title: "`r paste('Pollution Prevention Notice and open burning restrictions ended within', params$burnRestrictionArea)`"
-type: "pollution_prevention"
 date: "`r Sys.Date()`"
 params: 
   aqMet: "Sakshi Jain"
@@ -9,12 +7,6 @@ params:
   outputFormat: "markdown"
   customMessage: ""
   burnRestrictionArea: ""
-ice: "End"
-author: "`r params$aqMet`"
-customMessage: "`r params$customMessage`"
-location: "`r params$nearestMonitor`"
-outputFormat: "`r params$outputFormat`" 
-burnRestrictions: 0
 format:
   markdown: default
   pdf:

--- a/pollution_prevention_issue.qmd
+++ b/pollution_prevention_issue.qmd
@@ -1,6 +1,4 @@
 ---
-title: "`r paste('Pollution Prevention Notice and open burning restrictions are in effect within', params$burnRestrictionArea)`"
-type: "pollution_prevention"
 date: "`r Sys.Date()`"
 params: 
   ice: "Issue" # Issue; Continue
@@ -14,12 +12,6 @@ params:
   burnRestrictionArea: ""
   burnRestrictionEndDate: "2025-09-28"
   burnRestrictionEndTime: "12:00 PM"
-ice: "`r params$ice`"
-author: "`r params$aqMet`"
-customMessage: "`r params$customMessage`"
-location: "`r params$nearestMonitor`"
-outputFormat: "`r params$outputFormat`"
-burnRestrictions: "`r params$burnRestrictions`"
 format:
   markdown: default
   pdf:

--- a/wildfire_smoke_end.qmd
+++ b/wildfire_smoke_end.qmd
@@ -1,6 +1,4 @@
 ---
-title: "Air quality warning for wildfire smoke ended" 
-type: "wildfire_smoke" 
 date: "`r Sys.Date()`" 
 params: 
   aqMet: "Sakshi Jain" 
@@ -11,13 +9,6 @@ params:
   healthAuth: 
     - First Nations Health Authority 
     - Northern Health 
-ice: "End" 
-author: "`r params$aqMet`" 
-customMessage: "`r params$customMessage`" 
-lastWarning: "`r params$lastWarning`" 
-healthAuth: "`r paste(params$healthAuth, collapse=', ')`" 
-location: "`r params$location`"
-outputFormat: "`r params$outputFormat`" 
 format:
   markdown: default
   pdf:
@@ -175,7 +166,7 @@ if (params$outputFormat == "markdown") cat(logo_image_line, sep="\n\n")
 
 [`r paste(":::")`]{.content-visible when-format="markdown"}
 
-This Air Quality Warning for wildfire smoke that was last updated on `r format(as.Date(params$lastWarning), '%B %d, %Y')` has ended.
+The Air Quality Warning for wildfire smoke that was last updated on `r format(as.Date(params$lastWarning), '%B %d, %Y')` has ended.
 
 `r params$customMessage`
 

--- a/wildfire_smoke_issue.qmd
+++ b/wildfire_smoke_issue.qmd
@@ -1,12 +1,9 @@
 ---
-title: "Air quality warning in effect for wildfire smoke"
-type: "wildfire_smoke" 
 date: "`r Sys.Date()`"
 params:
   aqMet: "Sakshi Jain"
   smokeDuration: "`24-48 hours`"
   customMessage: "`Custom message.`"
-  ice: "Issue"
   nextUpdate: "2025-02-10"
   location: "Multiple locations in B.C."
   outputFormat: "markdown"
@@ -15,12 +12,6 @@ params:
     - Prince George
     - Whistler
     - South Okanagan
-ice: "`r params$ice`"
-author: "`r params$aqMet`"
-smokeDuration: "`r params$smokeDuration`"
-customMessage: "`r params$customMessage`"
-location: "`r params$location`"
-outputFormat: "`r params$outputFormat`" 
 format:
   markdown: default
   pdf:


### PR DESCRIPTION
fixes #91 

- created a boolean YAML `bylaw` in  `module_issue_local_emissions.r ` via the `quarto_render()` metadata argument
- it was necessary create `bylaw` in the module (instead of the YAML header in the `.qmd`) to avoid conversion from boolean to text; `bylaw` must be a boolean for proper rendering of the frontmatter table on the aqwarnings site
- `local_emissions_issue.qmd`: moved all existing dynamic top-level YAML parameters from the `.qmd` file to `quarto_render()` metadata argument in the shiny module to consolidate top-level YAML parameters in a single place
- all other `.qmd`: moved top-level YAML parameters from `.qmd` YAML header to `quarto_render()` metadata argument in the respective shiny modules to consolidate top-level YAML parameters in a single place and keep files consistent across type.
- for all modules, removed unnecessary items from execute_params and metadata args in `quarto_render()`, and alphabetized each
- verified that `.pdf` and `.md` outputs generate correctly, and the frontmatter table on aqwarnings repo populates correctly