### PR TITLE
correction to pollution prevention notice issue

### DIFF
--- a/pollution_prevention_issue.qmd
+++ b/pollution_prevention_issue.qmd
@@ -55,7 +55,7 @@ source(here::here(file.path("functions", "local_tz.r")))
 current_month <- as.numeric(format(Sys.Date(), "%m"))
 # create single line break based on output file format
 if (params$outputFormat == "markdown") sep_type <- "<br />" else sep_type <- "  \n"
-run_pg <- (params$location == "Prince George")  #to control conditional text related to Prince George only
+run_pg <- (params$nearestMonitor == "Prince George")  #to control conditional text related to Prince George only
 ```
 
 ```{r table-setup, include=FALSE}


### PR DESCRIPTION
Conditional PGAIR information was displaying when it shouldn't. Fix:
- corrected params reference from `params$location` to `params$nearestMonitor`
- `params$loctation` does not exist in the pollution prevention notice
